### PR TITLE
taskbar now looks more like win11

### DIFF
--- a/src/components/taskbar/taskbar.scss
+++ b/src/components/taskbar/taskbar.scss
@@ -2,9 +2,9 @@
   position: absolute;
   width: 100vw;
   height: 39px;
-  background: rgba(254, 254, 254, 0.8);
-  -webkit-backdrop-filter: blur(20px);
-  backdrop-filter: blur(20px);
+  background: rgb(243 243 243 / 85%);
+  -webkit-backdrop-filter: saturate(3) blur(20px);
+  backdrop-filter: saturate(3) blur(20px);
   bottom: 0;
   z-index: 10000;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/89068816/139572022-9e81757b-34c5-45d8-ae91-8aceffe4c112.png)
before

![image](https://user-images.githubusercontent.com/89068816/139572028-1eb55567-0235-4f36-b49a-60f477a59ff2.png)
after

updated taskbars background color (took exact value from win11 taskbar)