### PR TITLE
Change 404.html color to black.

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>404 - Page</title>
-  <link rel="stylesheet" href="https://win11.blueedge.me/style.css">
+  <link rel="stylesheet" href="./style.css">
 
 </head>
 <body>

--- a/public/404.html
+++ b/public/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>404 - Page</title>
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="https://win11.blueedge.me/style.css">
 
 </head>
 <body>

--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: Segoe UI;
-  background: #3973aa;
+  background: #000000;
   color: #fefeff;
   height: 100vh;
   margin: 0;


### PR DESCRIPTION
Windows 11's BSOD color has been updated to black, This is how it looks now:
![Windows11BSOD](https://user-images.githubusercontent.com/77000356/141261255-6590efe3-4286-4da0-a914-458f4c069ef1.jpg)
This is how the 404 page looks now
![appli](https://user-images.githubusercontent.com/77000356/141261280-ee7329f0-d263-4de0-958c-862fd05b9dad.PNG)
