### PR TITLE
few small fixes + updated lockscreen loader

### DIFF
--- a/src/components/start/sidepane.scss
+++ b/src/components/start/sidepane.scss
@@ -196,7 +196,7 @@ body[data-theme="dark"] .sidePane {
   top: 12px;
   left: 12px;
   bottom: 12px;
-  width: 610px;
+  width: 760px;
   border-radius: 8px;
   overflow: hidden;
   transform: translateX(0);

--- a/src/containers/applications/wnapp.scss
+++ b/src/containers/applications/wnapp.scss
@@ -77,6 +77,10 @@ body[data-theme="dark"] .wnstore {
   --rib2-bg: #2c2f32;
   --det-bg: #282c32;
   background: var(--bg-color);
+
+  .win11Scroll {
+    --scroll: rgb(44 44 44 / 80%);
+  }
 }
 
 .wnterm {

--- a/src/containers/background/back.scss
+++ b/src/containers/background/back.scss
@@ -25,17 +25,6 @@
   place-items: center;
   cursor: progress;
 }
-/* Loader css */
-
-#loader {
-  position: relative;
-  top: 0;
-  left: 0;
-  display: grid;
-  text-align: center;
-  align-items: center;
-  justify-content: center;
-}
 
 .lockscreen {
   position: absolute;
@@ -154,27 +143,39 @@
   animation: slowfadein 1s ease-in-out;
 }
 
-.loader-svg {
-  stroke-width: 8px;
+// Loader css
+#loader {
+  position: relative;
+  top: 0;
+  left: 0;
+  display: grid;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+}
+// https://docs.microsoft.com/en-us/fluent-ui/web-components/components/progress-ring
+
+.progressRing circle {
+  stroke: white;
+  fill: none;
+  stroke-width: 2px;
   stroke-linecap: round;
-  stroke: #fefefe;
-  stroke-dasharray: 242;
-  animation: fill-animation 1s linear infinite;
+  transform-origin: 50% 50%;
+  transition: all 0.2s ease-in-out 0s;
+  animation: 2s linear 0s infinite normal none running spin-infinite;
 }
 
-@keyframes fill-animation {
+@keyframes spin-infinite {
   0% {
-    stroke-dasharray: 40 242;
-    stroke-dashoffset: 282;
+    stroke-dasharray: 0.01px, 43.97px;
+    transform: rotate(0deg);
   }
-
   50% {
-    stroke-dasharray: 140;
-    stroke-dashoffset: 140;
+    stroke-dasharray: 21.99px, 21.99px;
+    transform: rotate(450deg);
   }
-
   100% {
-    stroke-dasharray: 40 242;
-    stroke-dashoffset: 0;
+    stroke-dasharray: 0.01px, 43.97px;
+    transform: rotate(1080deg);
   }
 }

--- a/src/containers/background/index.js
+++ b/src/containers/background/index.js
@@ -52,8 +52,8 @@ export const BootScreen = (props) => {
       <div className={blackout ? "hidden" : ""}>
         <Image src="asset/bootlogo" w={180} />
         <div className="mt-48" id="loader">
-          <svg class="svg-container" height="48" width="48" viewBox="0 0 100 100">
-            <circle class="loader-svg" cx="50" cy="50" r="45"></circle>
+          <svg class="progressRing" height={48} width={48} viewBox="0 0 16 16">
+            <circle cx="8px" cy="8px" r="7px"></circle>
           </svg>
         </div>
       </div>

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -284,8 +284,8 @@ export const ToolBar = (props)=>{
 
     if(op==0) setPos(pos0, pos1)
     else{
-      dim0 = Math.max(dim0, 360)
-      dim1 = Math.max(dim1, 360)
+      dim0 = Math.max(dim0, 320)
+      dim1 = Math.max(dim1, 320)
       pos0 = posP[0] + Math.min(vec[0],0)*(dim0 - dimP[0])
       pos1 = posP[1] + Math.min(vec[1],0)*(dim1 - dimP[1])
       setPos(pos0, pos1)

--- a/src/utils/general.scss
+++ b/src/utils/general.scss
@@ -1,5 +1,6 @@
 .toolbar {
   display: flex;
+  flex-shrink: 0;
   width: 100%;
   height: 26px;
   justify-content: space-between;


### PR DESCRIPTION
the lockscreen loader was updated using [fluent ui components](https://docs.microsoft.com/en-us/fluent-ui/web-components/components/progress-ring)

update scrollbar for store : earlier it was looking to light on store as on store overflow: overlay is being used
![unknown](https://user-images.githubusercontent.com/89068816/149710732-3f961086-5464-4479-96ac-e76b6454aaae.png)

fix calculator resizing

https://user-images.githubusercontent.com/89068816/149710830-d6bfc07c-e40e-4a67-b94b-036748c86dc7.mp4

Updated widget width to 760px (just like real win11 earler it looked lil bit small)

fixed toolbar getting smaller in some apps