### PR TITLE
Use `advanced-issue-labeler` action for issue labeling

### DIFF
--- a/.github/workflows/Issue-text.yml
+++ b/.github/workflows/Issue-text.yml
@@ -4,9 +4,15 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   comment:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
 
     steps:
       - uses: peter-evans/create-or-update-comment@v2
@@ -20,11 +26,11 @@ jobs:
         with:
           template-path: .github/ISSUE_TEMPLATE/bug_report.yml
 
-      - run: echo '${{ steps.issue-parser.outputs.jsonString }}'
-
-      - run: echo ${{ steps.issue-parser.outputs.issueparser_what_browser_are_you_seeing_the_problem_on }}
-
-      - uses: actions-ecosystem/action-add-labels@v1
+      - name: Set labels based on browsers field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v1
         with:
-          labels: ${{ steps.issue-parser.outputs.issueparser_what_browser_are_you_seeing_the_problem_on }}
-          github_token: ${{ secrets.BOT }}
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: browsers
+          block-list: |
+            Other Browser
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Update `Issue-text.yml` to be more secure and use more suitable action.

## Type of change

Instead of `actions-ecosystem/action-add-labels` action I added `redhat-plumbers-in-action/advanced-issue-labeler` action that is more suitable for use with issue forms. It provides so useful helpers to label issues based input provided via issue form.

Also please have a look at: https://github.com/stefanbuck/github-issue-parser/issues/24 - `echo '${{ steps.issue-parser.outputs.jsonString }}'` is not "safe" to use. There for I removed `run echo` stuff. Json will be still visible since it is passed as argument to `redhat-plumbers-in-action/advanced-issue-labeler` action.

- [x] New feature (non-breaking change which adds functionality)

> **Note** I added `Other Browser` option to block list, so if user will chose this option no label will be set. Do you prefere original behavior?
