### PR TITLE
Fixed click on items in Search tab #664

### DIFF
--- a/src/components/start/start.jsx
+++ b/src/components/start/start.jsx
@@ -416,9 +416,8 @@ export const StartMenu = () => {
 									<div className="topApps flex w-full justify-between">
 										{start.rcApps.slice(1, 7).map((app, i) => {
 											return (
-												<div key={i} className="topApp pt-6 py-4 ltShad">
+												<div key={i} className="topApp pt-6 py-4 ltShad" onClick={clickDispatch}>
 													<Icon
-														onClick={clickDispatch}
 														click={app.action}
 														payload={app.payload || "full"}
 														src={app.icon}


### PR DESCRIPTION
# Description

Before: I enter in the Search tab, I see all the items on Top Apps. When I click on an item, the click works only if I click on the image (but not on the item itself, for example in the grey background).
As a solution, now it is possible to click on the item instead of the image.
_- Hacktoberfest 2022 entry -_
Fixes #664

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
