### PR TITLE
Centered the suspense fallback Loading message

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -253,3 +253,12 @@ a {
   opacity: 0;
   pointer-events: none;
 }
+
+#sus-fallback {
+  width: 100%;
+  position: relative;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,7 +19,7 @@ Sentry.init({
 
 const root = createRoot(document.getElementById("root"));
 root.render(
-	<Suspense fallback={<h1>Loading...</h1>}>
+	<Suspense fallback={<div id="sus-fallback"><h1>Loading...</h1></div>}>
 		<Provider store={store}>
 			<App />
 		</Provider>


### PR DESCRIPTION
# Description
I centered the **`Loading...`** message part when the web is loading.I wrapped the `h1` in a `div`. Also i added an id to it and make apropiate **css changes** in index.css to have it centered in the midle of the screen
It isn´t such a relevant thing but it looks better if it is centered and not in the top left 

## Type of change

- [x] New feature (non-breaking change which adds functionality)