### PR TITLE
Fix: Microsoft Store doesn't scroll to top when the apps icon is clicked

### DIFF
--- a/src/containers/applications/apps/store.jsx
+++ b/src/containers/applications/apps/store.jsx
@@ -58,8 +58,10 @@ export const MicroStore = () => {
       payload = e.target.dataset.payload;
 
     // console.log(act, payload);
-    if (act == "page1") setPage(act[4]);
-    else if (act == "page2") {
+    if (act == "page1") {
+      setPage(act[4]);
+      document.querySelector(".restWindow.win11Scroll").scrollTop = 0;
+    } else if (act == "page2") {
       for (var i = 0; i < storeapps.length; i++) {
         if (storeapps[i].data.url == payload) {
           setOpapp(storeapps[i]);


### PR DESCRIPTION
# Description

When the apps icon is clicked in Windows Store application, the apps list opens a bit scrolled down, whereas the normal behaviour is to scroll to top. 

![image](https://user-images.githubusercontent.com/60311647/195456552-4bdaf5be-2743-4466-8324-45f329d4ef7b.png)


# Fixes (issue)
Added a line to scroll to top when the icon is clicked.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
