### PR TITLE
fix diagnostic & feedback name in settings

### DIFF
--- a/src/containers/applications/apps/assets/settingsData.json
+++ b/src/containers/applications/apps/assets/settingsData.json
@@ -568,7 +568,7 @@
     },
     {
       "type": "tile",
-      "name": "Diagnostic &amp; feedback",
+      "name": "Diagnostic & feedback",
       "desc": "Diagnostic data, inking and typing data, tailored experiences, feedback frequency",
       "icon": ""
     },


### PR DESCRIPTION
# Description

The settings name currently displays "Diagnostic &amp; feedback"

![image](https://user-images.githubusercontent.com/79479981/195995655-9de3c0c2-2f2a-48c4-bda0-0ac90b39c13c.png)

when it should be displaying "Diagnostic & feedback".

![image](https://user-images.githubusercontent.com/79479981/195995731-cff8c9de-9533-473e-8754-268c306bce75.png)

This PR fixes that.

## Fixes # (issue)

There was no issue created about this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
