### PR TITLE
fix sliderBackground name (typo)

### DIFF
--- a/src/components/start/index.jsx
+++ b/src/components/start/index.jsx
@@ -122,10 +122,10 @@ export const SidePane = () => {
 
 		dispatch({ type: "TASKAUDO", payload: aud });
 
-		silderBackground(vSlider, e.target.value);
+		sliderBackground(vSlider, e.target.value);
 	};
 
-	function silderBackground(elem, e) {
+	function sliderBackground(elem, e) {
 		elem.style.setProperty(
 			"--track-color",
 			`linear-gradient(90deg, var(--clrPrm) ${e - 3}%, #888888 ${e}%)`
@@ -142,7 +142,7 @@ export const SidePane = () => {
 				value: brgt,
 			},
 		});
-		silderBackground(bSlider, brgt);
+		sliderBackground(bSlider, brgt);
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
# Description

I fixed a typo in the `sliderBackground` function.

`silderBackground` => `sliderBackground`

## Fixes # (issue)

No issue number

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
