### PR TITLE
fix battery class name

### DIFF
--- a/src/components/start/index.jsx
+++ b/src/components/start/index.jsx
@@ -221,7 +221,7 @@ export const SidePane = () => {
 				</div>
 			</div>
 			<div className="p-1 bottomBar">
-				<div className="px-3 bettery">
+				<div className="px-3 battery-sidepane">
 					<Battery pct />
 				</div>
 			</div>

--- a/src/components/start/sidepane.scss
+++ b/src/components/start/sidepane.scss
@@ -196,7 +196,7 @@ body[data-theme="dark"] .bandpane {
     display: flex;
     align-items: center;
 
-    .bettery {
+    .battery-sidepane {
       height: 100%;
       display: flex;
       align-items: center;


### PR DESCRIPTION
# Description

The class name `bettery` looks like a typo, so it should be `battery` instead. However, it gets mixed with the other battery class name (the shared battery component), so I changed it to `battery-sidepane` to make them distinguishable.

Fixes # (issue)

No issue number

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
