### PR TITLE
"help -> COLOR" has been aligned correctly

### DIFF
--- a/src/containers/applications/apps/terminal.jsx
+++ b/src/containers/applications/apps/terminal.jsx
@@ -236,7 +236,7 @@ export const WnTerminal = () => {
       var helpArr = [
         "CD             Displays the name of or changes the current directory.",
         "CLS            Clears the screen.",
-        "COLOR		  	Sets the default console foreground and background colors.",
+        "COLOR		Sets the default console foreground and background colors.",
         "DATE           Displays or sets the date.",
         "DIR            Displays a list of files and subdirectories in a directory.",
         "ECHO           Displays messages, or turns command echoing on or off.",


### PR DESCRIPTION
# Description

For "help", the COLOR description was misaligned.

![Issue_Screenshot](https://user-images.githubusercontent.com/40722235/211204839-209bd3a4-4659-4e98-9e40-d2a4a6c2656f.png)

# Fix
Just removed extra spaces for linear look.