### PR TITLE
Fixing Flight Mode

### DIFF
--- a/src/components/taskbar/index.jsx
+++ b/src/components/taskbar/index.jsx
@@ -41,6 +41,25 @@ const Taskbar = () => {
     dispatch({ type: "TASKPHIDE" });
   };
 
+  const [conectivityToggle, setConectivityToggle] = useState("wifi");
+  const sidepane = useSelector((state) => state.sidepane);
+
+  useEffect(() => {
+    const wifi = document.querySelector('[data-payload="network.wifi.state"]');
+    let wifiState = wifi.getAttribute('data-state');
+
+    if (sidepane.quicks[2].ui === false) {
+      setConectivityToggle("airplane");
+      wifiState = "false";
+    } else {
+      setConectivityToggle("wifi");
+      wifiState = "true";
+    }
+
+    // Update the data-state attribute of the wifi element
+    wifi.setAttribute('data-state', wifiState);
+  }, [sidepane.quicks[2].ui]);
+
   const clickDispatch = (event) => {
     var action = {
       type: event.target.dataset.action,
@@ -143,7 +162,7 @@ const Taskbar = () => {
             onClick={clickDispatch}
             data-action="PANETOGG"
           >
-            <Icon className="taskIcon" src="wifi" ui width={16} />
+            <Icon className="taskIcon" src={conectivityToggle} ui width={16} />
             <Icon
               className="taskIcon"
               src={"audio" + tasks.audio}

--- a/src/reducers/sidepane.js
+++ b/src/reducers/sidepane.js
@@ -53,6 +53,10 @@ const paneReducer = (state = defState, action) => {
     var tmpState = { ...state };
     tmpState.quicks[4].src = action.payload;
     return tmpState;
+  } else if (action.type == "STNGTOGG" && action.payload === "network.airplane") {
+    var tmpState = { ...state };
+    tmpState.quicks[2].ui = !tmpState.quicks[2].ui;
+    return tmpState;
   } else if (action.type == "BANDTOGG") {
     return { ...state, banhide: !state.banhide };
   } else if (action.type == "BANDHIDE") {

--- a/src/utils/apps.js
+++ b/src/utils/apps.js
@@ -67,7 +67,8 @@ const apps = [
   {
     name: "Blue",
     icon: "win/user",
-    type: "short",
+    type: "app",
+    action: "EXPLORER",
   },
   {
     name: "Alarms",


### PR DESCRIPTION
# Description
when we click on Flight mode then is not changing the wifi icon to flight icon and also not off the wifi.
So use useEffect to listen when click on Flight mode then first change state the  sidepane reducer of airplaneMode(change ui to  true or false or vice versa) then target the wifi element with action payload(wifiElement) and also get another attribute of wifiElement of data state(when we click on sidepane icons it change data - state to true), here we use that to when we click on flight mode then we change the wifiElement(data - state) to false and also chnage the icon of wifi to airplane mode using useState to chnage the icon src.

## Type of change
Change in Taskbar index.js
Changes Reducer sidepane.js

[ ] Bug fix (non-breaking change which fixes an issue)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
