### PR TITLE
feat: Opening of corresponding apps upon clicking.

### DIFF
--- a/src/components/start/index.jsx
+++ b/src/components/start/index.jsx
@@ -80,9 +80,29 @@ export const BandPane = () => {
       style={{ "--prefix": "BAND" }}
     >
       <div className="bandContainer">
-        <Icon className="hvlight" src="defender" width={17} />
-        <Icon className="hvlight" src="spotify" width={17} />
-        <Icon className="hvlight" src="teams" width={17} />
+        <Icon
+          className="hvlight"
+          width={17}
+          click="CALCUAPP"
+          payload="togg"
+          open="true"
+          src="calculator"
+        />
+        <Icon
+          className="hvlight"
+          width={17}
+          click="SPOTIFY"
+          payload="togg"
+          open="true"
+          src="spotify"
+        />
+        <Icon
+          className="hvlight"
+          width={17}
+          click="NOTEPAD"
+          payload="togg"
+          src="notepad"
+        />
       </div>
     </div>
   );
@@ -128,7 +148,7 @@ export const SidePane = () => {
   function sliderBackground(elem, e) {
     elem.style.setProperty(
       "--track-color",
-      `linear-gradient(90deg, var(--clrPrm) ${e - 3}%, #888888 ${e}%)`,
+      `linear-gradient(90deg, var(--clrPrm) ${e - 3}%, #888888 ${e}%)`
     );
   }
 

--- a/src/utils/general.jsx
+++ b/src/utils/general.jsx
@@ -24,6 +24,8 @@ String.prototype.count = function (c) {
 };
 
 export const Icon = (props) => {
+  const sidepane = useSelector((state) => state.sidepane);
+
   const dispatch = useDispatch();
   var src = `img/icon/${props.ui != null ? "ui/" : ""}${props.src}.png`;
   if (props.ext != null || (props.src && props.src.includes("http"))) {
@@ -38,6 +40,8 @@ export const Icon = (props) => {
   }
 
   const clickDispatch = (event) => {
+    if (!sidepane.banhide) dispatch({ type: "BANDHIDE" });
+
     var action = {
       type: event.currentTarget.dataset.action,
       payload: event.currentTarget.dataset.payload,


### PR DESCRIPTION
# Description

<img width="86" alt="Screenshot 2023-10-05 161612" src="https://github.com/blueedgetechno/win11React/assets/110045644/7099c73a-df1f-4b28-826a-50cfa83d8db7">

When you click on these icons, they open the corresponding apps.
Few Changes: Since the Windows Defender and Microsoft Teams apps do not exist, I've replaced them with Calculator and Notepad.

Fixes #802 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
